### PR TITLE
FIX: todos API 수정

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 images
+build

--- a/server/src/app-data-source.ts
+++ b/server/src/app-data-source.ts
@@ -9,7 +9,7 @@ mysql 다운로드 받은 후 CREATE databases haru;
 그리고 password는 mysql을 다운로드 받을 때 설정한 password를 넣어주어야함
 이외에는 동일하게 설정
 */
-const myDataSource = new DataSource({
+const DB = new DataSource({
   type: "mysql",
   host: "127.0.0.1",
   port: 3306,
@@ -23,4 +23,4 @@ const myDataSource = new DataSource({
   charset: "utf8mb4",
 });
 
-export default myDataSource;
+export default DB;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,14 +1,13 @@
 import "./env.ts";
 import express, { Request, Response, NextFunction } from "express";
-import myDataSource from "./app-data-source";
+import DB from "./app-data-source";
 import router from "./routes";
 import passport from "passport";
 import passportOpt from "./passport";
 import cookies from "cookie-parser";
 
 // establish database connection
-myDataSource
-  .initialize()
+DB.initialize()
   .then(() => {
     console.log("Data Source has been initialized!");
   })

--- a/server/src/entity/todo-log.ts
+++ b/server/src/entity/todo-log.ts
@@ -1,14 +1,17 @@
 import {
   Column,
   CreateDateColumn,
+  Entity,
   PrimaryColumn,
+  PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
 
+@Entity()
 // Todo가 완료되는 시점을 기록하는 데이터의 Entity
 export class TodoLog {
   //id : auto Increment
-  @PrimaryColumn()
+  @PrimaryGeneratedColumn()
   id: number;
 
   @Column({ nullable: false })
@@ -21,7 +24,7 @@ export class TodoLog {
     type: "timestamp",
     default: () => "CURRENT_TIMESTAMP(6)",
   })
-  completedAt: Date;
+  createdAt: Date;
 
   @UpdateDateColumn({
     type: "timestamp",

--- a/server/src/entity/todo-log.ts
+++ b/server/src/entity/todo-log.ts
@@ -1,39 +1,27 @@
 import {
-  Entity,
   Column,
-  PrimaryGeneratedColumn,
   CreateDateColumn,
+  PrimaryColumn,
   UpdateDateColumn,
 } from "typeorm";
 
-//필요한 데이터베이스 스키마 entity에 생성
-
-@Entity()
-export class Todo {
+// Todo가 완료되는 시점을 기록하는 데이터의 Entity
+export class TodoLog {
   //id : auto Increment
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @Column({ nullable: false })
-  writer: string;
+  todoId: number;
 
   @Column({ nullable: false })
-  folder: string;
-
-  @Column({ nullable: false })
-  content: string;
-
-  @Column({ nullable: false })
-  dates: string; // string[]
-
-  @Column({ nullable: false })
-  days: string; // boolean[]
+  date: string;
 
   @CreateDateColumn({
     type: "timestamp",
     default: () => "CURRENT_TIMESTAMP(6)",
   })
-  createdAt: Date;
+  completedAt: Date;
 
   @UpdateDateColumn({
     type: "timestamp",

--- a/server/src/entity/todo-log.ts
+++ b/server/src/entity/todo-log.ts
@@ -2,13 +2,12 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  PrimaryColumn,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
 
 @Entity()
-// Todo가 완료되는 시점을 기록하는 데이터의 Entity
+// Todo의 일정을 기록하는 데이터의 Entity
 export class TodoLog {
   //id : auto Increment
   @PrimaryGeneratedColumn()
@@ -19,6 +18,9 @@ export class TodoLog {
 
   @Column({ nullable: false })
   date: string;
+
+  @Column({ nullable: false })
+  completed: boolean;
 
   @CreateDateColumn({
     type: "timestamp",

--- a/server/src/entity/todo.ts
+++ b/server/src/entity/todo.ts
@@ -24,9 +24,6 @@ export class Todo {
   content: string;
 
   @Column({ nullable: false })
-  dates: string; // string[]
-
-  @Column({ nullable: false })
   days: string; // boolean[]
 
   @CreateDateColumn({

--- a/server/src/passport/index.ts
+++ b/server/src/passport/index.ts
@@ -1,7 +1,7 @@
 import passport from "passport";
 import bcrypt from "bcrypt";
 import { User } from "../entity/user";
-import myDataSource from "../app-data-source";
+import DB from "../app-data-source";
 import { Strategy as LocalStrategy } from "passport-local";
 import { ExtractJwt, Strategy } from "passport-jwt";
 
@@ -13,9 +13,7 @@ const passportConfig = {
 
 const passportVerify = async (email: string, password: string, done: any) => {
   try {
-    const user = await myDataSource
-      .getRepository(User)
-      .findOneBy({ email: email });
+    const user = await DB.getRepository(User).findOneBy({ email: email });
 
     if (!user) {
       return done(null, false, { reason: "존재하지 않는 사용자입니다." });
@@ -58,9 +56,7 @@ const JWTVerify = async (token: any, done: any) => {
       return done(null, false, { reason: "token이 없습니다." });
     }
 
-    const user = await myDataSource
-      .getRepository(User)
-      .findOneBy({ email: token.email });
+    const user = await DB.getRepository(User).findOneBy({ email: token.email });
 
     if (!user) {
       console.log("token과 맞는 user가 없습니다.");

--- a/server/src/routes/comments.routes.ts
+++ b/server/src/routes/comments.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import express, { Request, Response, NextFunction } from "express";
-import myDataSource from "../app-data-source";
+import DB from "../app-data-source";
 import { Post } from "../entity/post";
 import { Comment } from "../entity/comment";
 import { Equal } from "typeorm";
@@ -21,7 +21,7 @@ router.get("/:postId", async (req: Request<PostParams>, res: Response) => {
   const postId = Number(req.params.postId);
   try {
     // postId로 게시물 하나의 데이터를 가져온다
-    const result = await myDataSource.getRepository(Comment).find({
+    const result = await DB.getRepository(Comment).find({
       where: { post: Equal(postId) },
     });
     return res.json(result);
@@ -35,10 +35,12 @@ router.post("/:email", async (req: Request, res: Response) => {
   //req.body에 있는 정보를 바탕으로 새로운 게시물 데이터를 생성한다.
   const writer = req.params.email;
 
-  const post = myDataSource
-    .getRepository(Comment)
-    .create({ ...req.body, post: req.body.postId, writer });
-  const result = await myDataSource.getRepository(Comment).save(post);
+  const post = DB.getRepository(Comment).create({
+    ...req.body,
+    post: req.body.postId,
+    writer,
+  });
+  const result = await DB.getRepository(Comment).save(post);
 
   return res.json(result);
 });
@@ -48,7 +50,7 @@ router.delete(
   "/:commentId",
   async (req: Request<CommentParams>, res: Response) => {
     const commentId = Number(req.params.commentId);
-    const result = await myDataSource.getRepository(Comment).update(
+    const result = await DB.getRepository(Comment).update(
       {
         id: commentId,
       },

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -4,6 +4,7 @@ import * as todos from "./todos.routes";
 import * as posts from "./posts.routes";
 import * as users from "./users.routes";
 import * as comments from "./comments.routes";
+import * as todo_logs from "./todo-logs.routes";
 
 const router = Router();
 // router.use(example.path, example.router);
@@ -13,5 +14,6 @@ router.use(users.path, users.router);
 router.use(todos.path, todos.router);
 router.use(posts.path, posts.router);
 router.use(comments.path, comments.router);
+router.use(todo_logs.path, todo_logs.router);
 
 export default router;

--- a/server/src/routes/posts.routes.ts
+++ b/server/src/routes/posts.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import express, { Request, Response, NextFunction } from "express";
-import myDataSource from "../app-data-source";
+import DB from "../app-data-source";
 import { Post } from "../entity/post";
 import { LessThan, MoreThan } from "typeorm";
 import multer, { FileFilterCallback } from "multer";
@@ -43,7 +43,7 @@ router.get(
   async (req: Request<PostParams>, res: Response) => {
     //마지막으로 읽은 postId를 바탕으로 이후 게시물 50개를 가져온다
     const readedPostId = Number(req.params.postId);
-    const result = await myDataSource.getRepository(Post).find({
+    const result = await DB.getRepository(Post).find({
       where: { id: LessThan(readedPostId) },
       take: 50,
       order: { id: "DESC" },
@@ -62,7 +62,7 @@ router.get("/:postId", async (req: Request<PostParams>, res: Response) => {
 
   try {
     //postId로 게시물 하나의 데이터를 가져온다
-    const result = await myDataSource.getRepository(Post).findOneOrFail({
+    const result = await DB.getRepository(Post).findOneOrFail({
       where: { id: postId },
     });
     return res.json(result);
@@ -79,8 +79,8 @@ router.post("/:email", async (req: Request, res: Response) => {
   console.log(req);
   const writer = req.params.email;
 
-  const post = myDataSource.getRepository(Post).create({ ...req.body, writer });
-  const result = await myDataSource.getRepository(Post).save(post);
+  const post = DB.getRepository(Post).create({ ...req.body, writer });
+  const result = await DB.getRepository(Post).save(post);
 
   return res.json(result);
 });
@@ -88,7 +88,7 @@ router.post("/:email", async (req: Request, res: Response) => {
 //게시물 삭제요청
 router.delete("/:postId", async (req: Request<PostParams>, res: Response) => {
   const postId = Number(req.params.postId);
-  const result = await myDataSource.getRepository(Post).delete(postId);
+  const result = await DB.getRepository(Post).delete(postId);
 
   //affected : 0 실패, affected : 1 성공
   if (!result.affected)
@@ -103,9 +103,10 @@ router.patch("/:postId", async (req: Request<PostParams>, res: Response) => {
   const content: string = req.body.content;
 
   // id가 postId에 해당하는 게시글의 content 수정
-  const result = await myDataSource
-    .getRepository(Post)
-    .update({ id: postId }, { content });
+  const result = await DB.getRepository(Post).update(
+    { id: postId },
+    { content }
+  );
 
   //affected : 0 실패, affected : 1 성공
   if (!result.affected)

--- a/server/src/routes/tests.routes.ts
+++ b/server/src/routes/tests.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import express, { Request, Response, NextFunction } from "express";
-import myDataSource from "../app-data-source";
+import DB from "../app-data-source";
 import { User } from "../entity/user";
 
 export const path = "/tests";
@@ -15,7 +15,7 @@ router.get("/", (req: Request, res: Response, next: NextFunction) => {
 //예시 DB호출하는 api
 //http://localhost:8000/api/tests/users/
 router.get("/users", async function (req: Request, res: Response) {
-  const users = await myDataSource.getRepository(User).find();
+  const users = await DB.getRepository(User).find();
   console.log("get /users 호출됨!");
   res.json(users);
 });

--- a/server/src/routes/todo-logs.routes.ts
+++ b/server/src/routes/todo-logs.routes.ts
@@ -1,6 +1,6 @@
 import { Request, Response, Router } from "express";
 import { Equal } from "typeorm";
-import myDataSource from "../app-data-source";
+import DB from "../app-data-source";
 import { TodoLog } from "../entity/todo-log";
 
 export const path = "/todo-logs";
@@ -8,7 +8,7 @@ export const router = Router();
 
 router.get("/", async (req: Request, res: Response) => {
   const todoId = req.body.todoId;
-  const logs = await myDataSource.getRepository(TodoLog).findBy({
+  const logs = await DB.getRepository(TodoLog).findBy({
     todoId: Equal(todoId),
   });
   return res.json(logs);

--- a/server/src/routes/todo-logs.routes.ts
+++ b/server/src/routes/todo-logs.routes.ts
@@ -1,0 +1,4 @@
+import { Router } from "express";
+
+export const path = "/todos";
+export const router = Router();

--- a/server/src/routes/todo-logs.routes.ts
+++ b/server/src/routes/todo-logs.routes.ts
@@ -1,4 +1,15 @@
-import { Router } from "express";
+import { Request, Response, Router } from "express";
+import { Equal } from "typeorm";
+import myDataSource from "../app-data-source";
+import { TodoLog } from "../entity/todo-log";
 
-export const path = "/todos";
+export const path = "/todo-logs";
 export const router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+  const todoId = req.body.todoId;
+  const logs = await myDataSource.getRepository(TodoLog).findBy({
+    todoId: Equal(todoId),
+  });
+  return res.json(logs);
+});

--- a/server/src/routes/todo-logs.routes.ts
+++ b/server/src/routes/todo-logs.routes.ts
@@ -1,15 +1,38 @@
 import { Request, Response, Router } from "express";
-import { Equal } from "typeorm";
 import DB from "../app-data-source";
 import { TodoLog } from "../entity/todo-log";
 
 export const path = "/todo-logs";
 export const router = Router();
 
-router.get("/", async (req: Request, res: Response) => {
-  const todoId = req.body.todoId;
-  const logs = await DB.getRepository(TodoLog).findBy({
-    todoId: Equal(todoId),
-  });
-  return res.json(logs);
-});
+// todoId가 일치하는 log들을 불러온다.
+// completed 값에 따라 값들을 가져온다.
+router.get(
+  "/",
+  async (
+    req: Request<{}, {}, { todoId: number; completed: boolean }>,
+    res: Response<TodoLog[]>
+  ) => {
+    const { todoId, completed } = req.body;
+    const logs = await DB.getRepository(TodoLog).findBy({
+      todoId,
+      completed: completed ?? false,
+    });
+    return res.json(logs);
+  }
+);
+
+// todoId가 일치하는 모든 log들을 불러온다.
+router.get(
+  "/all",
+  async (
+    req: Request<{}, {}, { todoId: number }>,
+    res: Response<TodoLog[]>
+  ) => {
+    const { todoId } = req.body;
+    const logs = await DB.getRepository(TodoLog).findBy({
+      todoId,
+    });
+    return res.json(logs);
+  }
+);

--- a/server/src/routes/todos.routes.ts
+++ b/server/src/routes/todos.routes.ts
@@ -1,5 +1,4 @@
 import { Request, Response, Router } from "express";
-import { Equal } from "typeorm";
 import DB from "../app-data-source";
 import { Todo } from "../entity/todo";
 import { TodoLog } from "../entity/todo-log";
@@ -229,7 +228,7 @@ router.patch(
     if (dates && dates.length) {
       result.push(
         await DB.getRepository(TodoLog).delete({
-          todoId: Equal(id),
+          todoId: id,
         })
       );
       console.log(dates);
@@ -264,8 +263,8 @@ router.patch(
 
     const result = await DB.getRepository(TodoLog).update(
       {
-        todoId: Equal(todoId),
-        date: Equal(date),
+        todoId,
+        date,
       },
       {
         completed,
@@ -289,7 +288,7 @@ router.delete(
 
     const result = await DB.getRepository(Todo).delete(id);
     await DB.getRepository(TodoLog).delete({
-      todoId: Equal(id),
+      todoId: id,
     });
     return res.json(result);
   }

--- a/server/src/routes/todos.routes.ts
+++ b/server/src/routes/todos.routes.ts
@@ -127,6 +127,9 @@ router.patch(
 router.patch(
   "/check",
   async (req: Request<{}, {}, { id: number; date: string }>, res: Response) => {
+    // date는 무조건 유효한 일자만 입력으로 주어진다고 가정한다.
+    // 이유는, 아이템이 클릭되었을때만 이 API가 호출되는데 해당되는 Todo 아이템은
+    // 정상적인 date를 가질 것이다.
     const { id, date } = req.body;
 
     if (!date || (date && !date.trim())) {

--- a/server/src/routes/todos.routes.ts
+++ b/server/src/routes/todos.routes.ts
@@ -40,6 +40,10 @@ router.get(
   }
 );
 
+// TODO: 사용자의 모든 데이터를 가져오기 (todo-log) 포함.
+router.get("/:email/all"),
+  async (req: Request<TodoParams>, res: Response<TodoResponseBody>) => {};
+
 // 사용자가 작성한 todo 중 folder가 일치하는 todo를 반환한다.
 router.get(
   "/:email/folder/:folder",
@@ -55,9 +59,31 @@ router.get(
   }
 );
 
+// 사용자가 작성한 todo 중 date가 일치하는 모든 todo를 반환한다.
 router.get(
   "/:email/date/:date",
-  async (req: Request<TodoParams>, res: Response<TodoResponseBody>) => {}
+  async (req: Request<TodoParams>, res: Response<TodoResponseBody>) => {
+    const { email: writer, date } = req.params;
+
+    const todos = await myDataSource.getRepository(Todo).findBy({
+      writer: Equal(writer),
+    });
+
+    const result: Todo[] = [];
+    for (const todo of todos) {
+      const todoLogs = await myDataSource
+        .getRepository(TodoLog)
+        .findAndCountBy({
+          todoId: Equal(todo.id),
+          date: Equal(date),
+        });
+      if (todoLogs[1]) {
+        result.push(todo);
+      }
+    }
+
+    return res.json(result);
+  }
 );
 
 // 사용자로부터 folder, content, dates, days를 받아서 todo table에 데이터를 저장한다.

--- a/server/src/routes/todos.routes.ts
+++ b/server/src/routes/todos.routes.ts
@@ -7,6 +7,8 @@ import { User } from "../entity/user";
 
 interface TodoParams {
   email: string;
+  folder: string;
+  date: string;
 }
 
 interface TodoRequestBody {
@@ -27,8 +29,6 @@ export const router = Router();
 router.get(
   "/:email",
   async (req: Request<TodoParams>, res: Response<TodoResponseBody>) => {
-    const result: TodoResponseBody = [];
-
     // email은 로그인된 사용자의 이메일을 가져오므로 항상 있다고 가정한다.
     const writer = req.params.email;
 
@@ -37,12 +37,29 @@ router.get(
       writer: Equal(writer),
     });
 
-    // 위에서 가져온 데이터를 결과값에 추가한다.
-    result.push(...todos);
-
     // 이 사용자가 가지고 있는 모든 todo를 반환한다.
-    return res.json(result);
+    return res.json(todos);
   }
+);
+
+// 사용자가 작성한 todo 중 folder가 일치하는 todo를 반환한다.
+router.get(
+  "/:email/folder/:folder",
+  async (req: Request<TodoParams>, res: Response<TodoResponseBody>) => {
+    const { email: writer, folder } = req.params;
+
+    const todos = await myDataSource.getRepository(Todo).findBy({
+      writer: Equal(writer),
+      folder: Equal(folder),
+    });
+
+    return res.json(todos);
+  }
+);
+
+router.get(
+  "/:email/date/:date",
+  async (req: Request<TodoParams>, res: Response<TodoResponseBody>) => {}
 );
 
 // 사용자로부터 folder, content, dates, days를 받아서 todo table에 데이터를 저장한다.

--- a/server/src/routes/todos.routes.ts
+++ b/server/src/routes/todos.routes.ts
@@ -63,29 +63,25 @@ router.post(
     ) {
       return res
         .status(400)
-        .send("folder, content, dates 중 하나의 값이 없습니다.");
+        .send("folder, content, dates, days 중 하나의 값이 없습니다.");
     }
 
-    const result: Todo[] = [];
-    for (const date of dates) {
-      // 입력 값에 따른 데이터를 생성한다.
-      const todo = await myDataSource.getRepository(Todo).create({
-        writer,
-        folder,
-        content,
-        dates: JSON.stringify(dates),
-        days: JSON.stringify(days),
-      });
+    // 입력 값에 따른 데이터를 생성한다.
+    const todo = await myDataSource.getRepository(Todo).create({
+      writer,
+      folder,
+      content,
+      dates: JSON.stringify(dates),
+      days: JSON.stringify(days),
+    });
 
-      // 위에서 생성한 todo 데이터를 table에 저장한다.
-      await myDataSource.getRepository(Todo).save(todo);
-      result.push(todo);
-    }
-    return res.json(result);
+    // 위에서 생성한 todo 데이터를 table에 저장한다.
+    await myDataSource.getRepository(Todo).save(todo);
+    return res.json(todo);
   }
 );
 
-// 사용자로부터 입력받은 데이터(folder, content, date)를 해당하는 todo를 id값을 기준으로 찾아 변경한다.
+// 사용자로부터 입력받은 데이터(folder, content, dates, days)를 해당하는 todo를 id값을 기준으로 찾아 변경한다.
 router.patch(
   "/",
   async (
@@ -120,6 +116,16 @@ router.patch(
     });
 
     return res.json(result);
+  }
+);
+
+// todo id값을 입력받아 해당하는 데이터를 찾은 후 date를 제거하거나, 추가한다.
+// 그리고 date를 제거하게 되면, todo-log에 추가하고,
+// 추가하게 된다면, todo-log에 있는지 확인하고, 제거한다.
+router.patch(
+  "/check",
+  async (req: Request<{ id: number; date: string }>, res: Response) => {
+    const { id, date } = req.body;
   }
 );
 

--- a/server/src/routes/users.routes.ts
+++ b/server/src/routes/users.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import express, { Request, Response, NextFunction } from "express";
-import myDataSource from "../app-data-source";
+import DB from "../app-data-source";
 import { User } from "../entity/user";
 import { Equal } from "typeorm";
 import bcrypt from "bcrypt"; // hashing 처리를 위한 라이브러리
@@ -82,9 +82,9 @@ router.post(
     }
 
     // email 중복 확인을 위한 변수
-    const overlap_check = await myDataSource
-      .getRepository(User)
-      .findOneBy({ email: Equal(email) });
+    const overlap_check = await DB.getRepository(User).findOneBy({
+      email: Equal(email),
+    });
 
     if (overlap_check) {
       // overlap_check가 null이 아니면 중복
@@ -100,13 +100,13 @@ router.post(
         if (err) return res.status(500).json("비밀번호 해쉬화에 실패");
         password = hash;
 
-        const result = await myDataSource.getRepository(User).create({
+        const result = await DB.getRepository(User).create({
           email: email,
           password: password,
           name: name,
         });
 
-        await myDataSource.getRepository(User).save(result);
+        await DB.getRepository(User).save(result);
         console.log("signup success");
         return res.send(result);
       });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -49,7 +49,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
## 개요
todos API 전반적인 수정이 이루어졌습니다.
DB의 변경이 있습니다.

## 상세 내용
- 기존에는 클라이언트에서 전역적으로 데이터를 관리하고 데이터 가공이 이루어졌지만, 이는 코드의 복잡성을 증가시키는 이유가 되는 것 같아, 서버에서 데이터를 필터링하고 정리할 수 있는 방식으로 수정하였습니다. 따라서 todo 필터링 API가 추가되었습니다.
- 클라이언트에서 보여주는 양이 많으면 렉이 걸리는 문제가 있어, 이를 해결하기 위해서 하나의 Todo를 여러 개로 보여주지 않고 하나로 보여주기 위해 DB의 변경이 있습니다.
  - todo 테이블이 기존과 다르게 completed, date의 정보를 가지지 않습니다.
  - todo-log 테이블이 새로 생성되었으며 이는 todo에 종속됩니다.
  - todo-log 테이블은 todo 테이블의 날짜, 생성 규칙에 따라 추가되고 삭제됩니다.
  - todo-log 테이블의 데이터는 todoId, date, completed를 데이터로 가집니다.
  - <img width="732" alt="스크린샷 2022-11-12 19 29 55" src="https://user-images.githubusercontent.com/55117867/201470256-18a84261-70f7-48de-896a-92ba482fe379.png">
