### PR TITLE
FIX: 사용자 데이터 입력 최대 제한, 업데이트시 기존 상태 불러오기 관련 문제 해결

### DIFF
--- a/HaruDemo/.idea/compiler.xml
+++ b/HaruDemo/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="1.8" />
   </component>
 </project>

--- a/HaruDemo/.idea/gradle.xml
+++ b/HaruDemo/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/HaruDemo/.idea/misc.xml
+++ b/HaruDemo/.idea/misc.xml
@@ -74,10 +74,7 @@
         <entry key="app/src/main/res/layout/login_layout.xml" value="0.11822916666666666" />
         <entry key="app/src/main/res/layout/my_dialog.xml" value="0.1752786220871327" />
         <entry key="app/src/main/res/layout/progress_bar.xml" value="0.375" />
-
         <entry key="app/src/main/res/layout/signup_layout.xml" value="0.5" />
-
-
         <entry key="app/src/main/res/layout/sns_comment_item.xml" value="0.2515625" />
         <entry key="app/src/main/res/layout/sns_image_item.xml" value="0.4276041666666667" />
         <entry key="app/src/main/res/layout/sns_post_add_image_item.xml" value="0.21927083333333333" />
@@ -87,7 +84,6 @@
         <entry key="app/src/main/res/layout/test_viewpager_frame1.xml" value="0.4114583333333333" />
         <entry key="app/src/main/res/layout/test_viewpager_frame2.xml" value="0.4125" />
         <entry key="app/src/main/res/layout/test_viewpager_frame3.xml" value="0.4125" />
-
         <entry key="app/src/main/res/menu/bottom_nav_menu.xml" value="0.25" />
         <entry key="app/src/main/res/menu/sample_menu.xml" value="0.346875" />
         <entry key="app/src/main/res/menu/sns_add_bottom_nav_menu.xml" value="0.21927083333333333" />
@@ -98,7 +94,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/HaruDemo/app/build.gradle
+++ b/HaruDemo/app/build.gradle
@@ -26,8 +26,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
         jvmTarget = '1.8'

--- a/HaruDemo/app/src/main/java/com/example/harudemo/fragments/TodoFragment.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/fragments/TodoFragment.kt
@@ -1,14 +1,11 @@
 package com.example.harudemo.fragments
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -16,13 +13,13 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.harudemo.R
 import com.example.harudemo.databinding.FragmentTodoBinding
 import com.example.harudemo.fragments.todo_fragments.TodoListFragment
-import com.example.harudemo.todo.TodoData
 import com.example.harudemo.todo.TodoInputActivity
 import com.example.harudemo.todo.adapters.TodoFolderListAdapter
-import com.example.harudemo.todo.types.Todo
-import com.example.harudemo.utils.API
-import com.example.harudemo.utils.Constants
-import com.example.harudemo.utils.CustomToast
+
+/**
+ * TODO: 사용자의 최대 Todo 개수 제한 필요
+ * FIXME: 업데이트 상태에서 기간 입력시 날짜 선택 안해도 기존 선택으로 가도록 수정
+ **/
 
 class TodoFragment : Fragment() {
     companion object {
@@ -39,7 +36,7 @@ class TodoFragment : Fragment() {
         val folderListAdapter: TodoFolderListAdapter
             get() {
                 if (_folderListAdapter == null) {
-                    _folderListAdapter = instance.activity?.let { TodoFolderListAdapter(it) }
+                    _folderListAdapter = TodoFolderListAdapter(instance.requireActivity())
                 }
                 return _folderListAdapter!!
             }

--- a/HaruDemo/app/src/main/java/com/example/harudemo/fragments/TodoFragment.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/fragments/TodoFragment.kt
@@ -17,8 +17,8 @@ import com.example.harudemo.todo.TodoInputActivity
 import com.example.harudemo.todo.adapters.TodoFolderListAdapter
 
 /**
- * TODO: 사용자의 최대 Todo 개수 제한 필요
  * FIXME: 업데이트 상태에서 기간 입력시 날짜 선택 안해도 기존 선택으로 가도록 수정
+ * FIXME: 삭제된 아이템 불러오지 않도록 수정
  **/
 
 class TodoFragment : Fragment() {

--- a/HaruDemo/app/src/main/java/com/example/harudemo/retrofit/RetrofitClient.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/retrofit/RetrofitClient.kt
@@ -61,38 +61,34 @@ object RetrofitClient {
 
 
         // 기본 파라미터 인터셉터 설정
-        val baseParameterInterceptor: Interceptor = (object : Interceptor {
-            override fun intercept(chain: Interceptor.Chain): Response {
-
-                Log.d(TAG, "RetrofitClient - intercept() called")
-                // 오리지널 리퀘스트
-                val originalRequest = chain.request()
-
-//                // 쿼리 파라미터 추가하기 추후 API KET 추가 용도
-//                val addedUrl =
-//                    originalRequest.url.newBuilder().addQueryParameter("client_id", API.API_KEY)
-//                        .build()
-//
-//                val finalRequest = originalRequest.newBuilder()
-//                    .url(addedUrl)
-//                    .method(originalRequest.method, originalRequest.body)
-//                    .build()
-//
-//                val response = chain.proceed(finalRequest)
-                Log.d("[debug]", originalRequest.toString())
-                val response = chain.proceed(originalRequest)
-                Log.d("[debug]", response.toString())
-                Log.d(TAG, "RetrofitClient - intercept() called response code : ${response.code}")
-                Log.d(TAG, "RetrofitClient - intercept() called response : ${response.body}")
-                if(response.code != 200){
-                    Handler(Looper.getMainLooper()).post {
-                        CustomToast.makeText(
-                            App.instance, "${response.code} 에러 입니다.", Toast.LENGTH_SHORT
-                        ).show()
-                    }
+        val baseParameterInterceptor: Interceptor = (Interceptor { chain ->
+            Log.d(TAG, "RetrofitClient - intercept() called")
+            // 오리지널 리퀘스트
+            val originalRequest = chain.request()
+            //                // 쿼리 파라미터 추가하기 추후 API KET 추가 용도
+            //                val addedUrl =
+            //                    originalRequest.url.newBuilder().addQueryParameter("client_id", API.API_KEY)
+            //                        .build()
+            //
+            //                val finalRequest = originalRequest.newBuilder()
+            //                    .url(addedUrl)
+            //                    .method(originalRequest.method, originalRequest.body)
+            //                    .build()
+            //
+            //                val response = chain.proceed(finalRequest)
+            Log.d("[debug]", originalRequest.toString())
+            val response = chain.proceed(originalRequest)
+            Log.d("[debug]", response.toString())
+            Log.d(TAG, "RetrofitClient - intercept() called response code : ${response.code}")
+            Log.d(TAG, "RetrofitClient - intercept() called response : ${response.body}")
+            if (response.code != 200) {
+                Handler(Looper.getMainLooper()).post {
+                    CustomToast.makeText(
+                        App.instance, "${response.code} 에러 입니다.", Toast.LENGTH_SHORT
+                    ).show()
                 }
-                return response
             }
+            response
         })
 
 

--- a/HaruDemo/app/src/main/java/com/example/harudemo/retrofit/TodoRetrofitManager.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/retrofit/TodoRetrofitManager.kt
@@ -40,11 +40,13 @@ class TodoRetrofitManager {
                     200 -> {
                         completion(RESPONSE_STATUS.OKAY, response.body())
                     }
+                    406 -> {
+                        completion(RESPONSE_STATUS.FAIL, response.body())
+                    }
                 }
             }
 
             override fun onFailure(call: Call<JsonElement>, t: Throwable) {
-                Log.d("[debug]", t.toString())
                 completion(RESPONSE_STATUS.FAIL, null)
             }
         })

--- a/HaruDemo/app/src/main/java/com/example/harudemo/todo/TodoData.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/todo/TodoData.kt
@@ -20,8 +20,8 @@ object TodoData {
             dates: List<String>,
             days: List<Boolean>,
             okayCallback: (JsonElement) -> Unit = {},
-            failCallback: (JsonElement) -> Unit = {},
-            noContentCallback: (JsonElement) -> Unit = {}
+            failCallback: () -> Unit = {},
+            noContentCallback: () -> Unit = {}
         ) {
             TodoRetrofitManager.instance.addTodo(
                 writer,
@@ -32,8 +32,8 @@ object TodoData {
                 completion = { responseStatus, response ->
                     when (responseStatus) {
                         RESPONSE_STATUS.OKAY -> response?.let(okayCallback)
-                        RESPONSE_STATUS.FAIL -> response?.let(failCallback)
-                        RESPONSE_STATUS.NO_CONTENT -> response?.let(noContentCallback)
+                        RESPONSE_STATUS.FAIL -> failCallback()
+                        RESPONSE_STATUS.NO_CONTENT -> noContentCallback()
                     }
                 })
         }

--- a/HaruDemo/app/src/main/java/com/example/harudemo/todo/TodoInputActivity.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/todo/TodoInputActivity.kt
@@ -117,9 +117,15 @@ class TodoInputActivity : AppCompatActivity() {
 
                 binding?.tvDurationStart?.text = startDate.toString()
                 binding?.tvDurationEnd?.text = endDate.toString()
+
+                for (i in 0 until todo.days.size) {
+                    if (todo.days[i]) {
+                        dayButtons[i + 1]?.isChecked = true
+                        days[i] = true
+                    }
+                }
             } else {
                 // 캘린더로 입력을 받았을 때
-                // 기간 선택 방식은 제외
                 viewMode = ViewMode.Calendar
                 binding?.cvDurationView?.visibility = View.GONE
             }

--- a/HaruDemo/app/src/main/java/com/example/harudemo/todo/TodoInputActivity.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/todo/TodoInputActivity.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import android.widget.ToggleButton
+import com.example.harudemo.App
 import com.example.harudemo.databinding.ActivityTodoInputBinding
 import com.example.harudemo.fragments.todo_fragments.DatePickerFragment
 import com.example.harudemo.fragments.todo_fragments.TodoListFragment
@@ -179,19 +180,13 @@ class TodoInputActivity : AppCompatActivity() {
 
                 // 시작 날짜가 끝 날짜를 넘어설 때까지 모든 날짜와 선택한 요일을 1:1로 확인하여 저장.
                 while (!startDate.isAfter(endDate)) {
-                    Log.d("[debug]", startDate.toString())
                     var day = startDate.dayOfWeek.value + 1
                     if (day == 8) day = 1
-                    Log.d(
-                        "[debug]",
-                        "$day ${dayButtons[day]?.isChecked}, ${dayButtons[day]?.text}"
-                    )
                     if (dayButtons[day]?.isChecked == true) {
                         datesList.add(startDate.toString())
                     }
                     startDate = startDate.plusDays(1)
                 }
-                Log.d("[debug]", days.toString())
             }
 
             if (folder.isBlank() || content.isBlank()) {
@@ -213,10 +208,17 @@ class TodoInputActivity : AppCompatActivity() {
                 TodoData.API.update(todo.id, folder, content, datesList, days)
             } else {
                 // DB에 데이터 추가
-                TodoData.API.create("cjeongmin27@gmail.com", folder, content, datesList, days)
+                TodoData.API.create("cjeongmin27@gmail.com", folder, content, datesList, days, {
+                }, {
+                    CustomToast.makeText(
+                        App.instance.applicationContext,
+                        "더 이상 Todo를 입력할 수 없습니다!!",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                })
             }
 
-            for(data in datesList) {
+            for (data in datesList) {
                 var splitdata = data.split("-")
 
 //                val calendar: Calendar = Calendar.getInstance().apply { // 1
@@ -265,7 +267,7 @@ class TodoInputActivity : AppCompatActivity() {
 
     // 입력에 문제가 있는지 판별하는 함수
     private fun validation(text: String): Boolean {
-        val regex = Regex("#[a-zA-Z0-9ㄱ-ㅎ가-힣]+\\s+[\\sa-zA-Z0-9ㄱ-ㅎ가-힣~!]+")
+        val regex = Regex("#[a-zA-Z0-9ㄱ-ㅎ가-힣]+\\s+[\\sa-zA-Z0-9ㄱ-ㅎ가-힣~!_\\-@#^*]+")
         return regex.matches(text)
     }
 

--- a/server/src/routes/todos.routes.ts
+++ b/server/src/routes/todos.routes.ts
@@ -20,6 +20,28 @@ router.post(
     // email은 로그인된 사용자의 이메일을 가져오므로 항상 있다고 가정한다.
     const writer = req.params.email;
 
+    // 삭제되지 않은 Todo의 개수를 파악 후 제한에 걸리는지 확인한다.
+    const todos = await DB.getRepository(Todo).findBy({
+      writer,
+      deleted: 0,
+    });
+
+    let todoCount = 0;
+    for (const todo of todos) {
+      const count = await DB.getRepository(TodoLog).countBy({
+        todoId: todo.id,
+        completed: 0,
+      });
+
+      if (count) {
+        todoCount++;
+      }
+    }
+
+    if (todoCount + 1 > 200) {
+      return res.status(406).send("Todo의 개수는 200개를 넘길 수 없습니다.");
+    }
+
     const { folder, content, dates, days } = req.body;
 
     // 혹시 입력으로부터 빠져있는 값이 있는지 확인한다.


### PR DESCRIPTION
## 개요
main 브랜치에 병합 후 몇가지 문제점을 발견하여 수정하는 작업을 거쳤습니다.

## 구현 내용
1. 사용자의 최대 Todo 데이터 입력을 제한하여 렉을 유발 할 수 있는 요소를 줄이고자 하였으며 최대를 넘는 요청을 할 경우 클라이언트로 알림이 가도록 구현하였습니다.
2. 일정한 규칙을 가지는 Todo 데이터의 업데이트를 위해 아이템 클릭시 해당 데이터의 기존 날짜를 가져오지 않아 날짜 입력을 강제하던 문제가 있어 날짜 변경을 원치 않을 경우 기존 날짜를 유지하도록 변경하였습니다.

## 수정 필요
- [ ] 많은 데이터가 있을 때, 데이터 추가하는 것이 오랜 시간이 걸리는 것으로 확인되어 메인 프래그먼트로 이동하여도 추가되지 않은 것처럼 보이는 작동을 하기에 수정이 필요합니다. 해결방안으로는 데이터 삽입에 있어 DB를 변경하여 모든 일정을 마친 데이터인지 확인하는 알고리즘을 변경하거나, 추가가 되었을 때 폴더를 불러오는 시작을 알리는 방식을 사용해도 좋을 것 같습니다.