### PR TITLE
FIX: 폴더 리스트 최적화

### DIFF
--- a/HaruDemo/app/src/main/java/com/example/harudemo/fragments/TodoFragment.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/fragments/TodoFragment.kt
@@ -14,7 +14,7 @@ import com.example.harudemo.R
 import com.example.harudemo.databinding.FragmentTodoBinding
 import com.example.harudemo.fragments.todo_fragments.TodoListFragment
 import com.example.harudemo.todo.TodoInputActivity
-import com.example.harudemo.todo.adapters.TodoFolderListAdapter
+import com.example.harudemo.todo.adapters.NewFolderListAdapter
 
 /**
  * FIXME: 업데이트 상태에서 기간 입력시 날짜 선택 안해도 기존 선택으로 가도록 수정
@@ -32,11 +32,11 @@ class TodoFragment : Fragment() {
                 return _instance!!
             }
 
-        private var _folderListAdapter: TodoFolderListAdapter? = null
-        val folderListAdapter: TodoFolderListAdapter
+        private var _folderListAdapter: NewFolderListAdapter? = null
+        val folderListAdapter: NewFolderListAdapter
             get() {
                 if (_folderListAdapter == null) {
-                    _folderListAdapter = TodoFolderListAdapter(instance.requireActivity())
+                    _folderListAdapter = NewFolderListAdapter(instance.requireActivity())
                 }
                 return _folderListAdapter!!
             }

--- a/HaruDemo/app/src/main/java/com/example/harudemo/todo/adapters/NewFolderListAdapter.kt
+++ b/HaruDemo/app/src/main/java/com/example/harudemo/todo/adapters/NewFolderListAdapter.kt
@@ -1,0 +1,73 @@
+package com.example.harudemo.todo.adapters
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.FragmentActivity
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.harudemo.R
+import com.example.harudemo.databinding.FragmentTodoFolderItemBinding
+import com.example.harudemo.fragments.todo_fragments.TodoListFragment
+import com.example.harudemo.todo.TodoData
+import com.example.harudemo.utils.CustomToast
+import com.example.harudemo.utils.User
+
+class NewFolderListAdapter(private val activity: FragmentActivity) :
+    ListAdapter<Pair<String, Int>, RecyclerView.ViewHolder>(object :
+        DiffUtil.ItemCallback<Pair<String, Int>>() {
+        override fun areItemsTheSame(oldItem: Pair<String, Int>, newItem: Pair<String, Int>): Boolean {
+            // areItemsTheSame => true 이여야만 areContentsTheSame도 확인함
+            // 이 어댑터는 아이템이 같은지는 별로 중요하지 않기에 항상 true를 리턴
+            // return oldItem === new Item
+            return true
+        }
+
+        override fun areContentsTheSame(oldItem: Pair<String, Int>, newItem: Pair<String, Int>): Boolean {
+            return oldItem == newItem
+        }
+    }) {
+
+    inner class ViewHolder(private val binding: FragmentTodoFolderItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bindItem(pair: Pair<String, Int>) {
+            binding.tvFolderTitle.text = pair.first
+            binding.tvCount.text = pair.second.toString()
+            binding.root.setOnClickListener {
+                val bundle = Bundle()
+                bundle.putString("by", "folder")
+                bundle.putString("folder-title", pair.first)
+
+                // Folder 클릭시에 TodoList에 폴더로부터 클릭 됬음을 알리면서 Fragment 전환
+                TodoListFragment.instance.arguments = bundle
+                activity.supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragments_frame, TodoListFragment.instance).commit()
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return ViewHolder(
+            FragmentTodoFolderItemBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is NewFolderListAdapter.ViewHolder) {
+            val pair = getItem(position)
+            holder.bindItem(pair)
+        }
+    }
+
+    fun fetchData() {
+        TodoData.API.getFoldersAndCount(User.info.email, {
+            submitList(it)
+        }, {
+            CustomToast.makeText(activity, "목록을 불러오지 못했습니다.", Toast.LENGTH_SHORT).show()
+        })
+    }
+}


### PR DESCRIPTION
## 개요
매번 폴더 리스트를 다시 화면에 표현할때 다시 그리던 현상을 최적화하였습니다.

## 상세내용
새로운 폴더 리스트 어댑터를 구현하였습니다.
 - 이전과 비교하여 폴더 이름 혹은 투두 데이터의 갯수에 따라 업데이트 됩니다.

## 참고사항
기존에 있던 폴더 리스트 어댑터 파일은 삭제하지 않고 일단 보관하고 있습니다. 추후에 문제가 없으면 삭제 후 새로운 어댑터 파일만 남기겠습니다.